### PR TITLE
Fix index.js serving and enhance todo UI

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -37,6 +37,13 @@ def index() -> FileResponse:
     return FileResponse(index_path)
 
 
+@app.get("/index.js")
+def index_js() -> FileResponse:
+    """Serve the bundled React application."""
+    js_path = os.path.join("frontend", "index.js")
+    return FileResponse(js_path)
+
+
 @app.get("/tasks")
 def list_tasks():
     with sqlite3.connect(DB_PATH) as conn:

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -47,11 +47,12 @@ function App() {
         <input value={title} onChange={e => setTitle(e.target.value)} placeholder="New task" />
         <button type="submit">Add</button>
       </form>
-      <ul>
+      <p>{tasks.filter(t => !t.completed).length} of {tasks.length} remaining</p>
+      <ul style={{ listStyle: 'none', padding: 0 }}>
         {tasks.map(task => (
-          <li key={task.id}>
+          <li key={task.id} style={{ display: 'flex', alignItems: 'center', marginBottom: '0.5rem' }}>
             <input type="checkbox" checked={task.completed} onChange={() => toggleTask(task.id, !task.completed)} />
-            {task.title}
+            <span style={{ flex: 1, marginLeft: '0.5rem', textDecoration: task.completed ? 'line-through' : 'none' }}>{task.title}</span>
             <button onClick={() => deleteTask(task.id)}>Delete</button>
           </li>
         ))}


### PR DESCRIPTION
## Summary
- serve frontend index.js file from FastAPI backend
- show remaining tasks and strikethrough completed ones

## Testing
- `python -m pip install -r backend/requirements.txt`
- `pytest -q`
- `uvicorn backend.main:app --port 8000 --reload` *(manual check)*

------
https://chatgpt.com/codex/tasks/task_e_6840e58ad6ac8329b7ac0db9aa7ee3d7