### PR TITLE
Add simple task animations

### DIFF
--- a/frontend/index.js
+++ b/frontend/index.js
@@ -69,7 +69,7 @@ function App() {
       <p>{tasks.filter(t => !t.completed).length} of {tasks.length} remaining</p>
       <ul style={{ listStyle: 'none', padding: 0 }}>
         {tasks.map(task => (
-          <li key={task.id} className={task.completed ? 'completed' : ''} style={{ display: 'flex', alignItems: 'center', marginBottom: '0.5rem' }}>
+          <li key={task.id} className={`fade-in ${task.completed ? 'completed' : ''}`} style={{ display: 'flex', alignItems: 'center', marginBottom: '0.5rem' }}>
             <input type="checkbox" checked={task.completed} onChange={() => toggleTask(task.id, !task.completed)} />
             <span style={{ flex: 1, marginLeft: '0.5rem' }}>
               {task.title}

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -40,3 +40,26 @@ button.button.is-danger {
 button.button.is-danger:hover {
   background-color: #ff3860;
 }
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.fade-in {
+  animation: fadeIn 0.4s ease-out;
+}
+
+button.button {
+  transition: background-color 0.3s, transform 0.2s;
+}
+
+button.button:hover {
+  transform: scale(1.05);
+}


### PR DESCRIPTION
## Summary
- fade tasks into view on page load
- animate buttons on hover for an interactive UI

## Testing
- `python -m py_compile backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6840f1507380832992dc772d6036ee53