### PR TITLE
Bugfix for add task UI and missing stylesheet

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -49,6 +49,13 @@ def index_js() -> FileResponse:
     return FileResponse(js_path)
 
 
+@app.get("/styles.css")
+def styles_css() -> FileResponse:
+    """Serve the Bulma-based stylesheet."""
+    css_path = os.path.join("frontend", "styles.css")
+    return FileResponse(css_path)
+
+
 @app.get("/tasks")
 def list_tasks(status: str | None = None):
     """List tasks filtered by status."""

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -21,7 +21,8 @@ function App() {
     });
     setTitle('');
     setDueDate('');
-    loadTasks();
+    // show newly added task by switching back to the "all" tab
+    setFilter('all');
   }
 
   async function toggleTask(id, completed) {


### PR DESCRIPTION
## Summary
- ensure new tasks appear by switching to the `all` tab after adding
- serve `styles.css` from FastAPI so the page loads CSS

## Testing
- `python -m py_compile backend/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6840f2f456fc8329a99d65577ceca80c